### PR TITLE
Deduplicate TruncateString helper

### DIFF
--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pascal71/lhcli/pkg/utils"
 )
 
 // Test data structures
@@ -171,7 +173,7 @@ func TestHelpers(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			result := TruncateString(test.input, test.maxLen)
+			result := utils.TruncateString(test.input, test.maxLen)
 			if result != test.expected {
 				t.Errorf("TruncateString(%s, %d) = %s, want %s",
 					test.input, test.maxLen, result, test.expected)

--- a/pkg/formatter/helpers.go
+++ b/pkg/formatter/helpers.go
@@ -91,19 +91,6 @@ func FormatMap(m map[string]string) string {
 	return strings.Join(pairs, ", ")
 }
 
-// TruncateString truncates a string to a maximum length
-func TruncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-
-	if maxLen <= 3 {
-		return s[:maxLen]
-	}
-
-	return s[:maxLen-3] + "..."
-}
-
 // FormatPercent formats a percentage value
 func FormatPercent(value, total float64) string {
 	if total == 0 {


### PR DESCRIPTION
## Summary
- remove `TruncateString` from formatter helpers
- rely on `utils.TruncateString` in tests

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68446e03f408832580d2727be552261c