### PR TITLE
Add version info command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version   string
+	buildDate string
+)
+
+// SetBuildInfo sets the build information for the version command.
+func SetBuildInfo(v, b string) {
+	version = v
+	buildDate = b
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Version: %s\n", version)
+		if buildDate != "" {
+			fmt.Printf("Build Date: %s\n", buildDate)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 func main() {
+	cmd.SetBuildInfo(Version, BuildDate)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,7 @@
+package main
+
+// Version of lhcli, injected at build time.
+var Version = "dev"
+
+// BuildDate is the build timestamp, injected at build time.
+var BuildDate = ""


### PR DESCRIPTION
## Summary
- add build info variables in `main`
- implement `version` subcommand
- inject build info at runtime

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68446dfaba5883258ecf10150bc8a744