### PR TITLE
Add diagnostics command for Longhorn

### DIFF
--- a/cmd/diagnostics.go
+++ b/cmd/diagnostics.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// diagnosticsCmd shows basic Longhorn diagnostic information.
+var diagnosticsCmd = &cobra.Command{
+	Use:     "diagnostics",
+	Aliases: []string{"diag"},
+	Short:   "Show Longhorn diagnostic information",
+	RunE:    runDiagnostics,
+}
+
+func init() {
+	rootCmd.AddCommand(diagnosticsCmd)
+}
+
+func runDiagnostics(cmd *cobra.Command, args []string) error {
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	// Fetch Longhorn version from settings if available
+	versionSetting, err := c.Settings().Get("current-longhorn-version")
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to get version: %v\n", err)
+	}
+
+	engineSetting, err := c.Settings().Get("default-engine-image")
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to get default engine image: %v\n", err)
+	}
+
+	fmt.Println("Longhorn Diagnostics")
+	if versionSetting != nil {
+		fmt.Printf("Version: %s\n", versionSetting.Value)
+	}
+	if engineSetting != nil {
+		fmt.Printf("Default Engine Image: %s\n", engineSetting.Value)
+	}
+
+	// List engine images to show active/default
+	engineImages, err := c.EngineImages().List()
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to list engine images: %v\n", err)
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Println("Engine Images:")
+	for _, ei := range engineImages {
+		mark := ""
+		if ei.Default {
+			mark = " (default)"
+		}
+		fmt.Printf("- %s%s\t%s\n", ei.Name, mark, ei.Image)
+	}
+
+	return nil
+}

--- a/pkg/client/engine_image.go
+++ b/pkg/client/engine_image.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// engineImageClient implements EngineImageInterface using the HTTP API
+
+// List retrieves all engine images.
+func (e *engineImageClient) List() ([]EngineImage, error) {
+	resp, err := e.client.doRequest("GET", "/engineimages", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Data []EngineImage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Data, nil
+}
+
+// Get retrieves a specific engine image.
+func (e *engineImageClient) Get(name string) (*EngineImage, error) {
+	resp, err := e.client.doRequest("GET", fmt.Sprintf("/engineimages/%s", name), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("engine image %s not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var ei EngineImage
+	if err := json.NewDecoder(resp.Body).Decode(&ei); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &ei, nil
+}
+
+// Delete removes an engine image.
+func (e *engineImageClient) Delete(name string) error {
+	resp, err := e.client.doRequest("DELETE", fmt.Sprintf("/engineimages/%s", name), nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/client/settings.go
+++ b/pkg/client/settings.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// settingsClient implements SettingsInterface using the HTTP API
+// This file provides real implementations for listing, retrieving and
+// updating Longhorn settings.
+
+// List retrieves all settings from the Longhorn API.
+func (s *settingsClient) List() (map[string]Setting, error) {
+	resp, err := s.client.doRequest("GET", "/settings", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Data []Setting `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	out := make(map[string]Setting)
+	for _, s := range result.Data {
+		out[s.Name] = s
+	}
+	return out, nil
+}
+
+// Get retrieves a single setting by name.
+func (s *settingsClient) Get(name string) (*Setting, error) {
+	resp, err := s.client.doRequest("GET", fmt.Sprintf("/settings/%s", name), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("setting %s not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var setting Setting
+	if err := json.NewDecoder(resp.Body).Decode(&setting); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &setting, nil
+}
+
+// Update updates the value of a Longhorn setting.
+func (s *settingsClient) Update(name string, value string) (*Setting, error) {
+	payload := map[string]string{
+		"value": value,
+	}
+
+	resp, err := s.client.doRequest("PUT", fmt.Sprintf("/settings/%s", name), payload)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var setting Setting
+	if err := json.NewDecoder(resp.Body).Decode(&setting); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &setting, nil
+}

--- a/pkg/client/stubs.go
+++ b/pkg/client/stubs.go
@@ -51,21 +51,6 @@ type settingsClient struct {
 	client *Client
 }
 
-func (s *settingsClient) List() (map[string]Setting, error) {
-	// TODO: Implement
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (s *settingsClient) Get(name string) (*Setting, error) {
-	// TODO: Implement
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (s *settingsClient) Update(name string, value string) (*Setting, error) {
-	// TODO: Implement
-	return nil, fmt.Errorf("not implemented")
-}
-
 // backupClient implements BackupInterface
 type backupClient struct {
 	client *Client
@@ -104,21 +89,6 @@ func (b *backupClient) SetTarget(target *BackupTarget) error {
 // engineImageClient implements EngineImageInterface
 type engineImageClient struct {
 	client *Client
-}
-
-func (e *engineImageClient) List() ([]EngineImage, error) {
-	// TODO: Implement
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (e *engineImageClient) Get(name string) (*EngineImage, error) {
-	// TODO: Implement
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (e *engineImageClient) Delete(name string) error {
-	// TODO: Implement
-	return fmt.Errorf("not implemented")
 }
 
 // eventClient implements EventInterface


### PR DESCRIPTION
## Summary
- implement `settingsClient` and `engineImageClient` to use HTTP API
- add new `diagnostics` command to print Longhorn version and engine images
- clean stubs from unused methods

## Testing
- `go fmt ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68451204dd1483258db66d31ae9c7c8a