### PR TITLE
Add troubleshooting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ lhcli monitor nodes
 lhcli monitor events --follow
 ```
 
+### Troubleshooting
+
+```bash
+# Run troubleshooting checks
+lhcli troubleshoot
+```
+
+This command inspects nodes, replicas and disks to report common issues such as orphaned replicas or low disk space.
+
 ## Development
 
 ### Building

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pascal71/lhcli/pkg/utils"
+)
+
+// troubleshootCmd represents the troubleshoot command
+var troubleshootCmd = &cobra.Command{
+	Use:   "troubleshoot",
+	Short: "Discover common Longhorn issues",
+	Long:  `Run a set of checks to find potential problems like orphaned replicas and resource shortages.`,
+	RunE:  runTroubleshoot,
+}
+
+func init() {
+	rootCmd.AddCommand(troubleshootCmd)
+}
+
+func runTroubleshoot(cmd *cobra.Command, args []string) error {
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	issues := []string{}
+
+	// Map of volumes for quick lookup
+	volumes, err := c.Volumes().List()
+	if err == nil {
+		volMap := make(map[string]struct{})
+		for _, v := range volumes {
+			volMap[v.Name] = struct{}{}
+		}
+
+		replicas, rerr := c.Replicas().List()
+		if rerr == nil {
+			for _, r := range replicas {
+				if _, exists := volMap[r.VolumeName]; !exists {
+					issues = append(issues, fmt.Sprintf("orphaned replica %s on node %s", r.Name, r.NodeID))
+				}
+			}
+		} else {
+			issues = append(issues, fmt.Sprintf("failed to list replicas: %v", rerr))
+		}
+	} else {
+		issues = append(issues, fmt.Sprintf("failed to list volumes: %v", err))
+	}
+
+	// Check node and disk status
+	nodes, nerr := c.Nodes().List()
+	if nerr == nil {
+		for _, n := range nodes {
+			if getNodeStatus(n) != "Ready" {
+				issues = append(issues, fmt.Sprintf("node %s is not ready", n.Name))
+			}
+			if !n.AllowScheduling {
+				issues = append(issues, fmt.Sprintf("node %s scheduling disabled", n.Name))
+			}
+			for id, d := range n.Disks {
+				if d.StorageMaximum > 0 && d.StorageAvailable*10 < d.StorageMaximum {
+					issues = append(issues,
+						fmt.Sprintf(
+							"low disk space on %s[%s]: %s free of %s",
+							n.Name,
+							id,
+							utils.FormatSize(d.StorageAvailable),
+							utils.FormatSize(d.StorageMaximum),
+						))
+				}
+			}
+		}
+	} else {
+		issues = append(issues, fmt.Sprintf("failed to list nodes: %v", nerr))
+	}
+
+	if len(issues) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No issues detected")
+		return nil
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Potential issues:")
+	for _, issue := range issues {
+		fmt.Fprintf(cmd.OutOrStdout(), "- %s\n", issue)
+	}
+	return nil
+}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -3,6 +3,7 @@ package monitor
 import (
     "context"
     "fmt"
+    "os"
     "time"
 )
 


### PR DESCRIPTION
## Summary
- add a `troubleshoot` command to identify common problems such as orphaned replicas and low disk space
- document the new troubleshooting feature
- fix missing import in monitor package

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68452dca21f48325abe3c49f98eab8a8