### PR TITLE
Implement snapshot create/delete

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -1,50 +1,117 @@
 package cmd
 
 import (
-    "fmt"
-    
-    "github.com/spf13/cobra"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pascal71/lhcli/pkg/client"
+	"github.com/pascal71/lhcli/pkg/formatter"
 )
 
 var snapshotCmd = &cobra.Command{
-    Use:   "snapshot",
-    Short: "Manage volume snapshots",
-    Long:  `Manage Longhorn volume snapshots including create, delete, and revert operations.`,
+	Use:   "snapshot",
+	Short: "Manage volume snapshots",
+	Long:  `Manage Longhorn volume snapshots including create, delete, and revert operations.`,
 }
 
 var snapshotCreateCmd = &cobra.Command{
-    Use:   "create [volume-name]",
-    Short: "Create a snapshot",
-    Long:  `Create a snapshot of the specified volume.`,
-    Args:  cobra.ExactArgs(1),
-    Run: func(cmd *cobra.Command, args []string) {
-        volumeName := args[0]
-        name, _ := cmd.Flags().GetString("name")
-        
-        fmt.Printf("Creating snapshot %s for volume %s...\n", name, volumeName)
-        // TODO: Implement snapshot create logic
-    },
+	Use:   "create [volume-name]",
+	Short: "Create a snapshot",
+	Long:  `Create a snapshot of the specified volume.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSnapshotCreate,
 }
 
 var snapshotListCmd = &cobra.Command{
-    Use:   "list [volume-name]",
-    Short: "List snapshots",
-    Long:  `List all snapshots for a specific volume.`,
-    Args:  cobra.ExactArgs(1),
-    Run: func(cmd *cobra.Command, args []string) {
-        volumeName := args[0]
-        fmt.Printf("Listing snapshots for volume %s...\n", volumeName)
-        // TODO: Implement snapshot list logic
-    },
+	Use:   "list [volume-name]",
+	Short: "List snapshots",
+	Long:  `List all snapshots for a specific volume.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSnapshotList,
+}
+
+var snapshotDeleteCmd = &cobra.Command{
+	Use:   "delete [volume-name] [snapshot-name]",
+	Short: "Delete a snapshot",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runSnapshotDelete,
+}
+
+func runSnapshotCreate(cmd *cobra.Command, args []string) error {
+	volumeName := args[0]
+	name, _ := cmd.Flags().GetString("name")
+	labels, _ := cmd.Flags().GetStringToString("labels")
+
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	input := &client.SnapshotCreateInput{
+		Name:   name,
+		Labels: labels,
+	}
+
+	if _, err := c.Snapshots().Create(volumeName, input); err != nil {
+		return fmt.Errorf("failed to create snapshot: %w", err)
+	}
+
+	fmt.Printf("✓ Snapshot %s created for volume %s\n", name, volumeName)
+	return nil
+}
+
+func runSnapshotList(cmd *cobra.Command, args []string) error {
+	volumeName := args[0]
+
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	snapshots, err := c.Snapshots().List(volumeName)
+	if err != nil {
+		return fmt.Errorf("failed to list snapshots: %w", err)
+	}
+
+	switch output {
+	case "json":
+		return formatter.NewJSONFormatter(true).Format(snapshots)
+	case "yaml":
+		return formatter.NewYAMLFormatter().Format(snapshots)
+	default:
+		for _, s := range snapshots {
+			fmt.Printf("%s\t%s\n", s.Name, s.Created)
+		}
+		return nil
+	}
+}
+
+func runSnapshotDelete(cmd *cobra.Command, args []string) error {
+	volumeName := args[0]
+	snapshotName := args[1]
+
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	if err := c.Snapshots().Delete(volumeName, snapshotName); err != nil {
+		return fmt.Errorf("failed to delete snapshot: %w", err)
+	}
+
+	fmt.Printf("✓ Snapshot %s deleted from volume %s\n", snapshotName, volumeName)
+	return nil
 }
 
 func init() {
-    rootCmd.AddCommand(snapshotCmd)
-    snapshotCmd.AddCommand(snapshotCreateCmd)
-    snapshotCmd.AddCommand(snapshotListCmd)
-    
-    // Snapshot create flags
-    snapshotCreateCmd.Flags().String("name", "", "Snapshot name")
-    snapshotCreateCmd.MarkFlagRequired("name")
-    snapshotCreateCmd.Flags().StringToString("labels", nil, "Labels for the snapshot")
+	rootCmd.AddCommand(snapshotCmd)
+	snapshotCmd.AddCommand(snapshotCreateCmd)
+	snapshotCmd.AddCommand(snapshotListCmd)
+	snapshotCmd.AddCommand(snapshotDeleteCmd)
+
+	// Snapshot create flags
+	snapshotCreateCmd.Flags().String("name", "", "Snapshot name")
+	snapshotCreateCmd.MarkFlagRequired("name")
+	snapshotCreateCmd.Flags().StringToString("labels", nil, "Labels for the snapshot")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -143,6 +143,14 @@ func (c *Client) Events() EventInterface {
 	return &eventClient{client: c}
 }
 
+// Snapshots returns the snapshot interface
+func (c *Client) Snapshots() SnapshotInterface {
+	if c.crdClient != nil {
+		return &crdSnapshotClient{crdClient: c.crdClient}
+	}
+	return &snapshotClient{client: c}
+}
+
 // NodeInterface defines node operations
 type NodeInterface interface {
 	List() ([]Node, error)
@@ -186,6 +194,13 @@ type BackupInterface interface {
 	Delete(backupName string) error
 	GetTarget() (*BackupTarget, error)
 	SetTarget(target *BackupTarget) error
+}
+
+// SnapshotInterface defines snapshot operations
+type SnapshotInterface interface {
+	List(volumeName string) ([]Snapshot, error)
+	Create(volumeName string, input *SnapshotCreateInput) (*Snapshot, error)
+	Delete(volumeName, snapshotName string) error
 }
 
 // EngineImageInterface defines engine image operations

--- a/pkg/client/snapshot.go
+++ b/pkg/client/snapshot.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// snapshotClient implements SnapshotInterface using HTTP API
+// It interacts with /volumes/{volume}/snapshots endpoints.
+type snapshotClient struct {
+	client *Client
+}
+
+// List returns all snapshots for a volume
+func (c *snapshotClient) List(volumeName string) ([]Snapshot, error) {
+	path := fmt.Sprintf("/volumes/%s/snapshots", volumeName)
+	resp, err := c.client.doRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Data []Snapshot `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Data, nil
+}
+
+// Create creates a snapshot for the given volume
+func (c *snapshotClient) Create(volumeName string, input *SnapshotCreateInput) (*Snapshot, error) {
+	path := fmt.Sprintf("/volumes/%s/snapshots", volumeName)
+	resp, err := c.client.doRequest("POST", path, input)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var snapshot Snapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &snapshot, nil
+}
+
+// Delete removes a snapshot from a volume
+func (c *snapshotClient) Delete(volumeName, snapshotName string) error {
+	path := fmt.Sprintf("/volumes/%s/snapshots/%s", volumeName, snapshotName)
+	resp, err := c.client.doRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/client/snapshot_crd.go
+++ b/pkg/client/snapshot_crd.go
@@ -1,0 +1,25 @@
+package client
+
+// snapshot_crd.go contains placeholder implementations for snapshot operations using Kubernetes CRDs.
+// At the moment these return a not implemented error to signal missing support.
+
+import "fmt"
+
+// crdSnapshotClient implements SnapshotInterface via Kubernetes CRDs
+// TODO: implement actual CRD logic if needed
+
+type crdSnapshotClient struct {
+	crdClient *LonghornCRDClient
+}
+
+func (c *crdSnapshotClient) List(volumeName string) ([]Snapshot, error) {
+	return nil, fmt.Errorf("snapshot list via CRD not implemented")
+}
+
+func (c *crdSnapshotClient) Create(volumeName string, input *SnapshotCreateInput) (*Snapshot, error) {
+	return nil, fmt.Errorf("snapshot create via CRD not implemented")
+}
+
+func (c *crdSnapshotClient) Delete(volumeName, snapshotName string) error {
+	return fmt.Errorf("snapshot delete via CRD not implemented")
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -160,6 +160,23 @@ type Replica struct {
 	CurrentImage    string            `json:"currentImage"` // K8s status field
 }
 
+// Snapshot represents a volume snapshot
+type Snapshot struct {
+	Name        string            `json:"name"`
+	Parent      string            `json:"parent"`
+	Created     string            `json:"created"`
+	Size        string            `json:"size"`
+	Labels      map[string]string `json:"labels"`
+	Removed     bool              `json:"removed"`
+	UserCreated bool              `json:"usercreated"`
+}
+
+// SnapshotCreateInput represents snapshot creation parameters
+type SnapshotCreateInput struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
+}
+
 // Setting represents a Longhorn setting
 type Setting struct {
 	Name       string            `json:"name"`

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -1,89 +1,90 @@
 package monitor
 
 import (
-    "context"
-    "fmt"
-    "time"
+	"context"
+	"fmt"
+	"os"
+	"time"
 )
 
 // Monitor interface for resource monitoring
 type Monitor interface {
-    Start(ctx context.Context, interval time.Duration) error
-    Stop()
+	Start(ctx context.Context, interval time.Duration) error
+	Stop()
 }
 
 // VolumeMonitor monitors volumes
 type VolumeMonitor struct {
-    client interface{} // TODO: Use actual client type
+	client interface{} // TODO: Use actual client type
 }
 
 // NewVolumeMonitor creates a new volume monitor
 func NewVolumeMonitor(client interface{}) *VolumeMonitor {
-    return &VolumeMonitor{client: client}
+	return &VolumeMonitor{client: client}
 }
 
 // Start starts monitoring volumes
 func (v *VolumeMonitor) Start(ctx context.Context, interval time.Duration) error {
-    ticker := time.NewTicker(interval)
-    defer ticker.Stop()
-    
-    for {
-        select {
-        case <-ctx.Done():
-            return ctx.Err()
-        case <-ticker.C:
-            if err := v.refresh(); err != nil {
-                fmt.Fprintf(os.Stderr, "Error refreshing volumes: %v\n", err)
-            }
-        }
-    }
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := v.refresh(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error refreshing volumes: %v\n", err)
+			}
+		}
+	}
 }
 
 // Stop stops monitoring
 func (v *VolumeMonitor) Stop() {
-    // TODO: Implement cleanup
+	// TODO: Implement cleanup
 }
 
 func (v *VolumeMonitor) refresh() error {
-    // TODO: Implement volume refresh logic
-    fmt.Println("Refreshing volumes...")
-    return nil
+	// TODO: Implement volume refresh logic
+	fmt.Println("Refreshing volumes...")
+	return nil
 }
 
 // NodeMonitor monitors nodes
 type NodeMonitor struct {
-    client interface{} // TODO: Use actual client type
+	client interface{} // TODO: Use actual client type
 }
 
 // NewNodeMonitor creates a new node monitor
 func NewNodeMonitor(client interface{}) *NodeMonitor {
-    return &NodeMonitor{client: client}
+	return &NodeMonitor{client: client}
 }
 
 // Start starts monitoring nodes
 func (n *NodeMonitor) Start(ctx context.Context, interval time.Duration) error {
-    ticker := time.NewTicker(interval)
-    defer ticker.Stop()
-    
-    for {
-        select {
-        case <-ctx.Done():
-            return ctx.Err()
-        case <-ticker.C:
-            if err := n.refresh(); err != nil {
-                fmt.Fprintf(os.Stderr, "Error refreshing nodes: %v\n", err)
-            }
-        }
-    }
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := n.refresh(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error refreshing nodes: %v\n", err)
+			}
+		}
+	}
 }
 
 // Stop stops monitoring
 func (n *NodeMonitor) Stop() {
-    // TODO: Implement cleanup
+	// TODO: Implement cleanup
 }
 
 func (n *NodeMonitor) refresh() error {
-    // TODO: Implement node refresh logic
-    fmt.Println("Refreshing nodes...")
-    return nil
+	// TODO: Implement node refresh logic
+	fmt.Println("Refreshing nodes...")
+	return nil
 }


### PR DESCRIPTION
## Summary
- add snapshot client and CRD stub
- expose snapshot interface via client
- implement snapshot create/list/delete commands
- fix missing os import in monitor

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68452ab5391883259bc02920d2f546c1